### PR TITLE
Make Design Injectable

### DIFF
--- a/Sources/SwiftMarkUp/MarkUpHeader.swift
+++ b/Sources/SwiftMarkUp/MarkUpHeader.swift
@@ -8,18 +8,9 @@
 import SwiftUI
 
 public struct MarkUpHeader: MarkUpView {
+    @Environment(\.headerStyle) private var headerStyle
     public enum Level {
         case one, two, three, four, five, six
-        var font: Font {
-            switch self {
-            case .one: return .largeTitle
-            case .two: return .title
-            case .three: return .title2
-            case .four: return .title3
-            case .five: return .headline
-            case .six: return .subheadline
-            }
-        }
     }
     private var text: LocalizedStringKey
     private var level: Level
@@ -32,8 +23,59 @@ public struct MarkUpHeader: MarkUpView {
         self.level = level
     }
     public var body: some View {
-        Text(self.text)
-            .font(self.level.font)
+        headerStyle.makeBody(Text(self.text), level: self.level)
+    }
+}
+
+public protocol HeaderStyle {
+    associatedtype Body: View
+    func makeBody(_ item: Text, level: MarkUpHeader.Level) -> Body
+}
+
+public struct DefaultHeaderStyle: HeaderStyle {
+    func font(level: MarkUpHeader.Level) -> Font {
+        switch level {
+        case .one: return .largeTitle
+        case .two: return .title
+        case .three: return .title2
+        case .four: return .title3
+        case .five: return .headline
+        case .six: return .subheadline
+        }
+    }
+    public func makeBody(_ item: Text, level: MarkUpHeader.Level) -> some View {
+        item
+            .font(font(level: level))
+    }
+}
+
+private struct AnyHeaderStyle: HeaderStyle {
+    private let makeBody: (Text, MarkUpHeader.Level) -> AnyView
+    init<S: HeaderStyle>(_ style: S) {
+        self.makeBody = { item, level in AnyView(style.makeBody(item, level: level))}
+    }
+    func makeBody(_ item: Text, level: MarkUpHeader.Level) -> some View {
+        self.makeBody(item, level)
+    }
+}
+
+private extension EnvironmentValues {
+    var headerStyle: AnyHeaderStyle {
+        get { self[HeaderStyleKey.self] }
+        set { self[HeaderStyleKey.self] = newValue }
+    }
+}
+private struct HeaderStyleKey: EnvironmentKey {
+    static let defaultValue: AnyHeaderStyle = .init(.default)
+}
+
+public extension HeaderStyle where Self == DefaultHeaderStyle {
+    static var `default`: Self { Self() }
+}
+
+public extension View {
+    func headerStyle<S: HeaderStyle>(_ style: S) -> some View {
+        self.environment(\.headerStyle, .init(style))
     }
 }
 

--- a/Sources/SwiftMarkUp/MarkUpQuote.swift
+++ b/Sources/SwiftMarkUp/MarkUpQuote.swift
@@ -47,7 +47,7 @@ public struct DefaultQuoteStyle: QuoteStyle {
     }
 }
 
-struct AnyQuoteStyle: QuoteStyle {
+private struct AnyQuoteStyle: QuoteStyle {
     private let makeBody: (Text, Int) -> AnyView
     init<S: QuoteStyle>(_ style: S) {
         self.makeBody = { item, level in AnyView(style.makeBody(item, level: level))}
@@ -57,13 +57,13 @@ struct AnyQuoteStyle: QuoteStyle {
     }
 }
 
-extension EnvironmentValues {
+private extension EnvironmentValues {
     var quoteStyle: AnyQuoteStyle {
         get { self[QuoteStyleKey.self] }
         set { self[QuoteStyleKey.self] = newValue }
     }
 }
-struct QuoteStyleKey: EnvironmentKey {
+private struct QuoteStyleKey: EnvironmentKey {
     static let defaultValue: AnyQuoteStyle = .init(.default)
 }
 

--- a/Tests/SwiftMarkUpTests/MarkUpBuildersTests.swift
+++ b/Tests/SwiftMarkUpTests/MarkUpBuildersTests.swift
@@ -6,7 +6,18 @@ import SwiftUI
 final class MarkUpBuildersTests: XCTestCase {
 
     @ViewBuilder func complileTestStyles() -> some View {
-        // MARK: Check quote operators
+        // MARK: Check header styles
+        MarkUp {
+            -"foo"
+            --"foo"
+            ---"foo"
+            ----"foo"
+            -----"foo"
+            ------"foo"
+        }
+        .headerStyle(.default)
+
+        // MARK: Check quote styles
         MarkUp {
             >"foo"
             >>"foo"

--- a/Tests/SwiftMarkUpTests/MarkUpBuildersTests.swift
+++ b/Tests/SwiftMarkUpTests/MarkUpBuildersTests.swift
@@ -5,6 +5,19 @@ import SwiftUI
 // this test includes compile test, which would fail if an operator has collision with other Swift operators
 final class MarkUpBuildersTests: XCTestCase {
 
+    @ViewBuilder func complileTestStyles() -> some View {
+        // MARK: Check quote operators
+        MarkUp {
+            >"foo"
+            >>"foo"
+            >>>"foo"
+            >>>>"foo"
+            >>>>>"foo"
+            >>>>>>"foo"
+        }
+        .quoteStyle(.default)
+    }
+    
     @ViewBuilder func complileTestOperators() -> some View {
         MarkUp {
             // MARK: Check link operator


### PR DESCRIPTION
Enable design injection using `@Environment`. 
In order to use `@Environment`, internally defined `AnyFooStyle`. However, `AnyFooStyle` is hidden in the library and won't be exposed to users.